### PR TITLE
Change company name

### DIFF
--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -13,8 +13,7 @@
   <p>
     De software waar de website op draait heet
     <a href="https://alaveteli.org">Alaveteli</a> en is ontwikkeld door
-    <a href="https://www.mysociety.org">mySociety</a>. mySociety is voortgekomen
-    uit de vereniging UK Citizens Online Democracy.
+    <a href="https://www.mysociety.org">mySociety</a>.
   </p>
 
   <p>

--- a/lib/views/help/faqs.html.erb
+++ b/lib/views/help/faqs.html.erb
@@ -368,8 +368,7 @@
   <p>
     De software waar de website op draait heet
     <a href="https://alaveteli.org">Alaveteli</a> en is ontwikkeld door
-    <a href="https://www.mysociety.org">mySociety</a>. mySociety is voortgekomen
-    uit de vereniging UK Citizens Online Democracy.
+    <a href="https://www.mysociety.org">mySociety</a>.
   </p>
 
   <p>


### PR DESCRIPTION
This PR removes (hopefully all) the references to the old company name UK Citizens Online Democracy.