### PR TITLE
[#26] Don't use IncomingMessage#specific_from_name

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -19,4 +19,10 @@ Rails.configuration.to_prepare do
   #     "If you uncomment this line, this text will appear as default text in every message"
   #   end
   # end
+
+  IncomingMessage.class_eval do
+    def specific_from_name?
+      false
+    end
+  end
 end


### PR DESCRIPTION
For reasons [1] it would make life easier if we only showed the
authority name instead of the `IncomingMessage#specific_from_name` on
incoming message correspondence.

Currently we only use `specific_from_name?` for this display check, so
easy enough to override it to `false` so that we always fall back to the
authority name.

Fixes https://github.com/mysociety/wob-knop-theme/issues/26.

**Before**

![Screenshot 2020-09-10 at 12 48 03](https://user-images.githubusercontent.com/282788/92725438-11416900-f364-11ea-80e2-6729b0e29701.png)


**After**

![Screenshot 2020-09-10 at 12 48 46](https://user-images.githubusercontent.com/282788/92725429-0dade200-f364-11ea-9922-9a9d69ce269f.png)


[1] https://groups.google.com/a/mysociety.org/g/alaveteli/c/SQtduOc_46Y/m/joEXtpUJAQAJ
[2] https://github.com/mysociety/alaveteli/search?q=specific_from_name%3F&unscoped_q=specific_from_name%3F